### PR TITLE
Default value for cmoRequestsFilter

### DIFF
--- a/src/main/java/org/mskcc/smile/publisher/pipeline/smile_server/SmileServiceReader.java
+++ b/src/main/java/org/mskcc/smile/publisher/pipeline/smile_server/SmileServiceReader.java
@@ -21,7 +21,7 @@ public class SmileServiceReader implements ItemStreamReader<String> {
     @Value("#{jobParameters[requestIds]}")
     private String requestIds;
 
-    @Value("#{jobParameters[cmoRequestsFilter]}")
+    @Value("#{jobParameters[cmoRequestsFilter] ?: true}")
     private Boolean cmoRequestsFilter;
 
     @Autowired


### PR DESCRIPTION
Message publisher will filter out non-cmo requests in `-m` mode if `cmoRequestsFilter` is not explicitly set to false. 

**TODO**: update README.md with the latest instructions to run the publisher and introduce the multiple modes the publisher can run in.

Signed-off-by: Divya Madala <71040191+divyamadala30@users.noreply.github.com>
