### PR TITLE
Request fetching now POSTs a list of request ids

### DIFF
--- a/src/main/java/org/mskcc/smile/publisher/pipeline/smile_server/SmileServiceUtil.java
+++ b/src/main/java/org/mskcc/smile/publisher/pipeline/smile_server/SmileServiceUtil.java
@@ -1,6 +1,9 @@
 package org.mskcc.smile.publisher.pipeline.smile_server;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -25,28 +28,28 @@ public class SmileServiceUtil {
 
     /**
      * Given a requestID, returns response from the SMILE web service.
-     * @param requestId
+     * @param requestIds
      * @return String
      * @throws Exception
      */
-    public String getRequestById(String requestId) throws Exception {
-        String requestUrl = smileBaseUrl + smileRequestEndpoint + requestId;
+    public String getRequestsById(List<String> requestIds) throws Exception {
+        String requestUrl = smileBaseUrl + smileRequestEndpoint;
         RestTemplate restTemplate = new RestTemplate();
-        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = getRequestEntity();
+        HttpEntity<LinkedMultiValueMap<String, Object>> requestEntity = getRequestEntity(requestIds);
         ResponseEntity responseEntity = restTemplate.exchange(requestUrl,
-                HttpMethod.GET, requestEntity, Object.class);
+                HttpMethod.POST, requestEntity, Object.class);
         String requestJsonString = mapper.writeValueAsString(responseEntity.getBody());
         return requestJsonString;
     }
 
     /**
      * Returns request entity.
+     * @param requestIds
      * @return HttpEntity
      */
-    private HttpEntity getRequestEntity() {
+    private HttpEntity getRequestEntity(List<String> requestIds) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        return new HttpEntity<Object>(headers);
+        return new HttpEntity<Object>(requestIds, headers);
     }
-
 }

--- a/src/main/resources/application.properties.EXAMPLE
+++ b/src/main/resources/application.properties.EXAMPLE
@@ -37,3 +37,4 @@ smile.publishing_failures_filepath=
 smile.base_url=
 smile.request_endpoint=
 smile.cmo_new_request_topic=
+smile.request_id.chunk_size=


### PR DESCRIPTION
For performance boost, fetching of requests is done via POST endpoint passing a list of request ids in chunks specified by property in application.properties.